### PR TITLE
add azd ai template gallery link to AI tutorials

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -54,8 +54,10 @@ Welcome to the Book of AI, where you'll learn everything you need to know to get
 
     **Azure.AI.Inference**  
     [:material-console: Azure AI Model Catalog](/setup/azure-ai.md)  
-    [:material-console: GitHub Model Marketplace](/setup/github.md)  
+    [:material-console: GitHub Model Marketplace](/setup/github.md) 
 
+    **Azure Developer CLI (azd)**  
+    [:material-console: AI Template Gallery](https://azure.github.io/ai-app-templates/)  
 
 -   :simple-onnx:{ .lg .middle } __ONNX GenAI Tutorials__
 


### PR DESCRIPTION
This PR adds a new section for the Azure Developer CLI (azd) and a link to the AI Template Gallery within `docs/index.md`

<img width="443" alt="Screenshot 2024-11-27 at 18 53 51" src="https://github.com/user-attachments/assets/1eec95bf-e144-4a01-95c0-4b2b55b14422">
