### PR TITLE
fix: correct syntax in speech synthesis command examples

### DIFF
--- a/docs/reference/cli/speech/synthesize.md
+++ b/docs/reference/cli/speech/synthesize.md
@@ -37,5 +37,5 @@ ai speech synthesize --text "Hello world" --speakers
 ```
 
 ``` bash title="Synthesize text to an audio file"
-ai speech synthesize --text "Hello world" --audio-output output hello_world.wav
+ai speech synthesize --text "Hello world" --audio-output hello_world.wav
 ```

--- a/scratch/ai-speech-in-tool-help.md
+++ b/scratch/ai-speech-in-tool-help.md
@@ -8425,7 +8425,7 @@ EXAMPLES
   ai speech synthesize --files *.txt;*.ssml --audio output {id}.wav --zip test2.zip
   ai speech synthesize --files @URLs.txt --output zip output.zip --zip test3.zip
 
-  ai speech synthesize --foreach file;audio.output in @filelist.txt --zip test4.job --zip output output.zip
+  ai speech synthesize --foreach file in @filelist.txt --zip test4.job --zip output.zip
   ai webjob --upload test4.zip --run
 
 SEE ALSO

--- a/scratch/all-in-tool-help-content.md
+++ b/scratch/all-in-tool-help-content.md
@@ -10532,7 +10532,7 @@ EXAMPLES
   ai speech synthesize --files *.txt;*.ssml --audio output {id}.wav --zip test2.zip
   ai speech synthesize --files @URLs.txt --output zip output.zip --zip test3.zip
 
-  ai speech synthesize --foreach file;audio.output in @filelist.txt --zip test4.job --zip output output.zip
+  ai speech synthesize --foreach file in @filelist.txt --zip test4.job --zip output.zip
   ai webjob --upload test4.zip --run
 
 SEE ALSO


### PR DESCRIPTION
This pull request includes updates to the documentation for the `ai speech synthesize` command to correct syntax errors and improve consistency. The most important changes include fixing the `--audio-output` argument and simplifying the `--foreach` argument usage in examples.

Documentation updates:

* [`docs/reference/cli/speech/synthesize.md`](diffhunk://#diff-1faeb50d7f46b7e694acb74c5dd9f8c7d56132684967a9292f4688b8a316a4a8L40-R40): Corrected the `--audio-output` argument in the example command to ensure proper syntax.
* [`scratch/ai-speech-in-tool-help.md`](diffhunk://#diff-04aee8c1bebd0c687290aaba5d19ec0a3174a1a519f5f5e44d0de7ae643f808dL8428-R8428): Simplified the `--foreach` argument usage in the example command for clarity and consistency.
* [`scratch/all-in-tool-help-content.md`](diffhunk://#diff-0c02cf35b53c625f830b4020f8cb012c7e3461bb02d0ed66f62af5350d045eaaL10535-R10535): Simplified the `--foreach` argument usage in the example command for clarity and consistency.